### PR TITLE
Fix build errors for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ interrupting and resuming an SGX enclave through our framework.
 2. The processor executes the AEX procedure that securely stores execution
    context in the enclave’s SSA frame, initializes CPU registers, and vectors
    to the (user space) interrupt handler registered in the IDT.
-3. At this point, any attack-specific, spy code can easily be plugged in. 
-4. The library returns to the user space AEP trampoline. We modified the 
+3. At this point, any attack-specific, spy code can easily be plugged in.
+4. The library returns to the user space AEP trampoline. We modified the
    untrusted runtime of the official SGX SDK to allow easy registration of a
    custom AEP stub. Furthermore, to enable precise evaluation of our approach on
    attacker-controlled benchmark debug enclaves, SGX-Step can *optionally* be
@@ -123,8 +123,8 @@ Pass the desired boot parameters to the kernel as follows:
 
 ```bash
 $ sudo vim /etc/default/grub
-  # GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nox2apic iomem=relaxed no_timer_check nosmep nosmap clearcpuid=514 isolcpus=1 nmi_watchdog=0"
-$ sudo update-grub && sudo reboot
+  # Add the following line: GRUB_CMDLINE_LINUX_DEFAULT="quiet splash nox2apic iomem=relaxed no_timer_check nosmep nosmap clearcpuid=514 isolcpus=1 nmi_watchdog=0"
+$ sudo update-grub && reboot
 ```
 
 Finally, in order to reproduce our experimental results, make sure to disable
@@ -282,7 +282,7 @@ with recent ucode, from only 34 with pre-Foreshadow ucode).
 The additional flushing operations may furthermore somewhat increase the
 variance of enclave entry time, which implies that you might have to
 configure the timer more conservatively with more zero-steps (which can be
-deterministically filtered out as explained above). 
+deterministically filtered out as explained above).
 
 
 
@@ -324,4 +324,3 @@ a pull request if your project uses SGX-Step but is not included below.
 | Single Trace Attack Against RSA Key Generation in Intel SGX SSL | [AsiaCCS18](https://rspreitzer.github.io/publications/proc/asiaccs-2018-paper-1.pdf) | - | Page fault |
 | Off-Limits: Abusing Legacy x86 Memory Segmentation to Spy on Enclaved Execution | [ESSoS18](https://people.cs.kuleuven.be/~jo.vanbulck/essos18.pdf) | [link](https://distrinet.cs.kuleuven.be/software/off-limits/) | Single-stepping, IA32 segmentation, page fault |
 | SGX-Step: A Practical Attack Framework for Precise Enclave Execution Control | [SysTEX17](https://people.cs.kuleuven.be/~jo.vanbulck/systex17.pdf) | [link](https://github.com/jovanbulck/sgx-step/tree/master/app/bench) | Single-stepping, page fault, PTE A/D|
-

--- a/install_SGX_SDK.sh
+++ b/install_SGX_SDK.sh
@@ -1,6 +1,27 @@
 #!/bin/bash
 set -e
 
+OS_VERS=$(lsb_release -r 2>/dev/null | awk '{ print $2 }')
+UBUNTU=$(uname -v | grep -c Ubuntu)
+
+echo $OS_VERS
+
+if [ "$UBUNTU" = 1 ]; then
+    if [ "$OS_VERS" = "18.04" ]; then
+        OS_STR="ubuntu18.04"
+    else
+        if [ "$OS_VERS" = "20.04" ]; then
+            OS_STR="ubuntu20.04"
+        else
+            echo "Unsupported OS version"
+            exit 1
+        fi
+    fi
+else
+    echo "Please set your operating system manually"
+    exit 1
+fi
+
 git submodule init
 git submodule update
 
@@ -20,7 +41,9 @@ sudo apt-get install libssl-dev libcurl4-openssl-dev protobuf-compiler libprotob
 # ----------------------------------------------------------------------
 echo "[ building SDK ]"
 cd linux-sgx
-./download_prebuilt.sh
+make preparation
+pwd
+sudo cp "external/toolset/$OS_STR/"* /usr/local/bin
 make -j`nproc`
 make sdk_install_pkg
 


### PR DESCRIPTION
The built-in toolchain on Ubuntu does not have some compiler flags required by the SGX-SDK repository, so I integrated the missing step of copying the updated mitigation tools.

I also made some minor changes to the readme that seemed beneficial while going through the installation steps for the first time.

Currently the build script for the SDK only supports Ubuntu, and requires the user to edit the shell script for it to work on other distributions. If needed, I can try to add support for more distros, but I will not be able to test whether they work correctly.