### PR TITLE
Add debug opt-in

### DIFF
--- a/libsgxstep/enclave.c
+++ b/libsgxstep/enclave.c
@@ -195,6 +195,13 @@ void* get_enclave_ssa_gprsgx_adrs(void)
     return get_enclave_base() + ossa + (cssa * SGX_SSAFRAMESIZE) - SGX_GPRSGX_SIZE;
 }
 
+void set_debug_optin(void) 
+{
+    void *tcs_addr = sgx_get_tcs();
+    uint64_t flags = 0x1;
+    edbgwr(tcs_addr + 8, &flags, sizeof(flags));
+}
+
 void print_enclave_info(void)
 {
     uint64_t read = 0xff;

--- a/libsgxstep/enclave.h
+++ b/libsgxstep/enclave.h
@@ -106,5 +106,7 @@ void dump_gprsgx_region(gprsgx_region_t *gprsgx_region);
 uint64_t edbgrd_ssa_gprsgx(int gprsgx_field_offset);
 #define edbgrd_erip() edbgrd_ssa_gprsgx(SGX_GPRSGX_RIP_OFFSET)
 
+void set_debug_optin(void);
+
 #endif
 #endif


### PR DESCRIPTION
Add a helper function to enable the debug opt-in for SGX, which can be used to single-step a debug enclave with a trap signal handler.