### PR TITLE
Signal handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,17 @@
 *.mk
 *.mod
 *.swn
+
+# Ignore cache directories
+*.cache/
+**/.cache/
+
+# Ignore compile command files
+compile_commands.json
+
+# Ignore backup files
+*.bak
+
+# Ignore tags file (for ctags or similar)
+tags
+

--- a/libsgxstep/counter.c
+++ b/libsgxstep/counter.c
@@ -1,0 +1,4 @@
+#include "counter.h"
+
+struct _counter counter = {0};
+

--- a/libsgxstep/counter.h
+++ b/libsgxstep/counter.h
@@ -1,0 +1,15 @@
+#ifndef SGX_STEP_COUNTER_H
+#define SGX_STEP_COUNTER_H
+
+struct _counter {
+    int irq_cnt;
+    int do_irq;
+    int fault_cnt;
+    int trigger_cnt;
+    int step_cnt;
+    int aep_cnt;
+};
+
+extern struct _counter counter;
+
+#endif

--- a/libsgxstep/pt.c
+++ b/libsgxstep/pt.c
@@ -312,3 +312,5 @@ void print_mapping( address_mapping_t *map )
 		printf( "                           |- phys address:      0x%" PRIx64 "\n", PT_PHYS( map->pte ) + virt_index( map, PAGE )  );
 	}
 }
+
+struct _address address = {NULL};

--- a/libsgxstep/pt.h
+++ b/libsgxstep/pt.h
@@ -176,4 +176,14 @@ void print_pte_adrs( void *adrs);
 void print_pte( uint64_t *pte );
 void print_mapping( address_mapping_t *map );
 
+struct _address {
+  uint64_t *pte_encl;
+  uint64_t *pte_trigger;
+  uint64_t *pmd_encl;
+  void *code_adrs;
+  void *trigger_adrs;
+};
+
+extern struct _address address;
+
 #endif

--- a/libsgxstep/sh.c
+++ b/libsgxstep/sh.c
@@ -1,0 +1,44 @@
+#include "sh.h"
+
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "debug.h"
+
+// One signal_handler_cb per signo
+signal_handler_t signal_handler_cb[32] = {NULL};
+
+void signal_handler_wrapper(int signo, siginfo_t *info, void *context) {
+    ASSERT(!(info == NULL || info->si_addr == NULL));
+
+    ucontext_t *u_context = (ucontext_t *)context;
+
+    if (signal_handler_cb[signo]) {
+#if DEBUG
+        info("Calling handler for signal %d", signo);
+#endif
+        signal_handler_cb[signo](info, u_context);
+    } else {
+        info("Caught unregistered signal %d", signo);
+        abort();
+    }
+}
+
+void register_signal_handler(signal_handler_t cb, int signo) {
+    struct sigaction act, old_act;
+
+    /* Specify handler with signinfo arguments */
+    memset(&act, 0, sizeof(struct sigaction));
+    act.sa_sigaction = signal_handler_wrapper;
+    act.sa_flags = SA_RESTART | SA_SIGINFO;
+
+    /* Block all signals while the signal is being handled */
+    sigfillset(&act.sa_mask);
+    ASSERT(!sigaction(signo, &act, &old_act));
+
+    signal_handler_cb[signo] = cb;
+#if DEBUG
+    info("Registered a handler for signal %d", signo);
+#endif
+}

--- a/libsgxstep/sh.h
+++ b/libsgxstep/sh.h
@@ -1,0 +1,16 @@
+#ifndef SGX_STEP_SH_H
+#define SGX_STEP_SH_H
+
+#include <signal.h>
+#include <stddef.h>
+
+// Define a type for the fault handler callback function
+typedef void (*signal_handler_t)(siginfo_t *, ucontext_t *);
+
+// Declare the external fault handler callback variable
+extern signal_handler_t signal_handler_cb[32];
+
+// Function to register a fault handler
+void register_signal_handler(signal_handler_t handler, int signo);
+
+#endif  // PF_H


### PR DESCRIPTION
This is step [1/n] for abstracting out the signal handler (including page fault handler).
[2/n] is to take out sigsegv handler from apps to the library as the default.

Question before I push [2/n]:
Should fault counters be held within the library or in the app?