### PR TITLE
fix: always install rdmsr/wrmsr call gates, checksys for x2apic opt out & selftest fix

### DIFF
--- a/app/selftest/cpl/asm.S
+++ b/app/selftest/cpl/asm.S
@@ -1,3 +1,4 @@
+#include "../../../libsgxstep/config.h"
 #define IA32_TIME_STAMP_COUNTER 0x10
 #define IA32_APIC_ID            0x802
 
@@ -9,7 +10,11 @@ do_rdmsr:
     mov %rax, gate_cpl(%rip)
 
     # store privileged RDMSR result
+#if X2APIC
     mov $IA32_APIC_ID, %ecx
+#else 
+    mov $IA32_TIME_STAMP_COUNTER, %ecx
+#endif
     rdmsr
     shl $32, %rdx
     or  %rdx, %rax

--- a/app/selftest/cpl/asm.S
+++ b/app/selftest/cpl/asm.S
@@ -1,4 +1,3 @@
-#include "../../../libsgxstep/config.h"
 #define IA32_TIME_STAMP_COUNTER 0x10
 #define IA32_APIC_ID            0x802
 
@@ -10,11 +9,7 @@ do_rdmsr:
     mov %rax, gate_cpl(%rip)
 
     # store privileged RDMSR result
-#if X2APIC
-    mov $IA32_APIC_ID, %ecx
-#else 
     mov $IA32_TIME_STAMP_COUNTER, %ecx
-#endif
     rdmsr
     shl $32, %rdx
     or  %rdx, %rax

--- a/check_sys.sh
+++ b/check_sys.sh
@@ -55,6 +55,7 @@ start_check "recommended SGX-Step parameters"
 sgxstep_cmdline=`cat README.md | extract_quoted "quiet splash "`
 kernel_cmdline=`cat /proc/cmdline`
 config_x2apic=$(grep -E '#define\s+X2APIC\s+[01]' libsgxstep/config.h | awk '{print $3}')
+dmesg_x2apic_opt_out=$(dmesg 2>&1 | grep "BIOS sets x2apic opt out bit")
 
 for c in $sgxstep_cmdline
 do
@@ -62,9 +63,12 @@ do
 done
 
 if [ "$config_x2apic" -eq 0 ]; then
-    assert_contains "$kernel_cmdline" "nox2apic" "not in /proc/cmdline, but config.h defines X2APIC=0"
+	if [[ ! "$dmesg_x2apic_opt_out" =~ "BIOS sets x2apic opt out bit" ]]; then
+		assert_contains "$kernel_cmdline" "nox2apic" "not in /proc/cmdline, but config.h defines X2APIC=0"
+	fi
 else
     assert_not_contains "$kernel_cmdline" "nox2apic" "in /proc/cmdline, but config.h defines X2APIC=1"
+    assert_not_contains "$dmesg_x2apic_opt_out" "BIOS sets x2apic opt out bit" "x2apic is disabled, but config.h defines X2APIC=1"
 fi
 end_check
 
@@ -88,14 +92,18 @@ end_check
 ############################################################################
 start_check "CPU features"
 cpuinfo=`cat /proc/cpuinfo`
+dmesg_x2apic_opt_out=$(dmesg 2>&1 | grep "BIOS sets x2apic opt out bit")
 assert_not_contains "$cpuinfo" "smap"   "not disabled in /proc/cpuinfo"
 assert_not_contains "$cpuinfo" "smep"   "not disabled in /proc/cpuinfo"
 assert_not_contains "$cpuinfo" "umip"   "not disabled in /proc/cpuinfo"
 
 if [ "$config_x2apic" -eq 0 ]; then
-    assert_not_contains "$cpuinfo" "x2apic" "not disabled in /proc/cpuinfo, but config.h defines X2APIC=0"
+	if [[ ! "$dmesg_x2apic_opt_out" =~ "BIOS sets x2apic opt out bit" ]]; then
+    		assert_not_contains "$cpuinfo" "x2apic" "not disabled in /proc/cpuinfo, but config.h defines X2APIC=0"
+	fi
 else
-    assert_contains "$cpuinfo" "x2apic" "not enabled in /proc/cpuinfo, but config.h defines X2APIC=1"
+    	assert_contains "$cpuinfo" "x2apic" "not enabled in /proc/cpuinfo, but config.h defines X2APIC=1"
+    	assert_not_contains "$dmesg_x2apic_opt_out" "BIOS sets x2apic opt out bit" "x2apic is disabled, but config.h defines X2APIC=1"
 fi
 end_check
 

--- a/check_sys.sh
+++ b/check_sys.sh
@@ -55,6 +55,7 @@ start_check "recommended SGX-Step parameters"
 sgxstep_cmdline=`cat README.md | extract_quoted "quiet splash "`
 kernel_cmdline=`cat /proc/cmdline`
 config_x2apic=$(grep -E '#define\s+X2APIC\s+[01]' libsgxstep/config.h | awk '{print $3}')
+dmesg_output=$(dmesg 2>&1)
 dmesg_x2apic_opt_out=$(dmesg 2>&1 | grep "BIOS sets x2apic opt out bit")
 
 for c in $sgxstep_cmdline
@@ -63,18 +64,16 @@ do
 done
 
 if [ "$config_x2apic" -eq 0 ]; then
-	if [[ ! "$dmesg_x2apic_opt_out" =~ "BIOS sets x2apic opt out bit" ]]; then
-		assert_contains "$kernel_cmdline" "nox2apic" "not in /proc/cmdline, but config.h defines X2APIC=0"
-	fi
+	assert_contains "$kernel_cmdline" "nox2apic" "not in /proc/cmdline, but config.h defines X2APIC=0"
 else
-    assert_not_contains "$kernel_cmdline" "nox2apic" "in /proc/cmdline, but config.h defines X2APIC=1"
-    assert_not_contains "$dmesg_x2apic_opt_out" "BIOS sets x2apic opt out bit" "x2apic is disabled, but config.h defines X2APIC=1"
+    	assert_not_contains "$kernel_cmdline" "nox2apic" "in /proc/cmdline, but config.h defines X2APIC=1"
+    	assert_not_contains "$dmesg_output" "BIOS sets x2apic opt out bit" \
+		"even if X2APIC=1 in config.h and nox2apic absent from /proc/cmdline, BIOS is opting out; try intremap=no_x2apic_opt_out in kernel params or disable x2apic"
 fi
 end_check
 
 ############################################################################
 start_check "unknown kernel parameters"
-dmesg_output=$(dmesg 2>&1)
 unknown_cmdline=`echo "$dmesg_output" | extract_quoted 'Unknown kernel command line parameters "'`
 
 assert_not_contains "$dmesg_output" "Operation not permitted" ": run this script as root"
@@ -92,18 +91,16 @@ end_check
 ############################################################################
 start_check "CPU features"
 cpuinfo=`cat /proc/cpuinfo`
-dmesg_x2apic_opt_out=$(dmesg 2>&1 | grep "BIOS sets x2apic opt out bit")
 assert_not_contains "$cpuinfo" "smap"   "not disabled in /proc/cpuinfo"
 assert_not_contains "$cpuinfo" "smep"   "not disabled in /proc/cpuinfo"
 assert_not_contains "$cpuinfo" "umip"   "not disabled in /proc/cpuinfo"
 
 if [ "$config_x2apic" -eq 0 ]; then
-	if [[ ! "$dmesg_x2apic_opt_out" =~ "BIOS sets x2apic opt out bit" ]]; then
-    		assert_not_contains "$cpuinfo" "x2apic" "not disabled in /proc/cpuinfo, but config.h defines X2APIC=0"
-	fi
+    	assert_not_contains "$cpuinfo" "x2apic" "not disabled in /proc/cpuinfo, but config.h defines X2APIC=0"
 else
     	assert_contains "$cpuinfo" "x2apic" "not enabled in /proc/cpuinfo, but config.h defines X2APIC=1"
-    	assert_not_contains "$dmesg_x2apic_opt_out" "BIOS sets x2apic opt out bit" "x2apic is disabled, but config.h defines X2APIC=1"
+    	assert_not_contains "$dmesg_output" "BIOS sets x2apic opt out bit" \
+		"even if X2APIC=1 in config.h and x2apic enabled in /proc/cpuinfo, BIOS is opting out; try intremap=no_x2apic_opt_out in kernel params or disable x2apic"
 fi
 end_check
 

--- a/check_sys.sh
+++ b/check_sys.sh
@@ -56,7 +56,8 @@ sgxstep_cmdline=`cat README.md | extract_quoted "quiet splash "`
 kernel_cmdline=`cat /proc/cmdline`
 config_x2apic=$(grep -E '#define\s+X2APIC\s+[01]' libsgxstep/config.h | awk '{print $3}')
 dmesg_output=$(dmesg 2>&1)
-dmesg_x2apic_opt_out=$(dmesg 2>&1 | grep "BIOS sets x2apic opt out bit")
+
+assert_not_contains "$dmesg_output" "Operation not permitted" ": run this script as root"
 
 for c in $sgxstep_cmdline
 do
@@ -64,11 +65,11 @@ do
 done
 
 if [ "$config_x2apic" -eq 0 ]; then
-	assert_contains "$kernel_cmdline" "nox2apic" "not in /proc/cmdline, but config.h defines X2APIC=0"
+    assert_contains "$kernel_cmdline" "nox2apic" "not in /proc/cmdline, but config.h defines X2APIC=0"
 else
-    	assert_not_contains "$kernel_cmdline" "nox2apic" "in /proc/cmdline, but config.h defines X2APIC=1"
-    	assert_not_contains "$dmesg_output" "BIOS sets x2apic opt out bit" \
-		"even if X2APIC=1 in config.h and nox2apic absent from /proc/cmdline, BIOS is opting out; try intremap=no_x2apic_opt_out in kernel params or disable x2apic"
+    assert_not_contains "$kernel_cmdline" "nox2apic" "in /proc/cmdline, but config.h defines X2APIC=1"
+    assert_not_contains "$dmesg_output" "BIOS sets x2apic opt out bit" \
+	    "even if X2APIC=1 in config.h and nox2apic absent from /proc/cmdline, BIOS is opting out; try intremap=no_x2apic_opt_out in kernel params or disable x2apic"
 fi
 end_check
 
@@ -76,7 +77,6 @@ end_check
 start_check "unknown kernel parameters"
 unknown_cmdline=`echo "$dmesg_output" | extract_quoted 'Unknown kernel command line parameters "'`
 
-assert_not_contains "$dmesg_output" "Operation not permitted" ": run this script as root"
 for c in $unknown_cmdline
 do
     # NOTE: pti=off wrongly reported as unknown by Linux kernel < 6.7
@@ -96,11 +96,9 @@ assert_not_contains "$cpuinfo" "smep"   "not disabled in /proc/cpuinfo"
 assert_not_contains "$cpuinfo" "umip"   "not disabled in /proc/cpuinfo"
 
 if [ "$config_x2apic" -eq 0 ]; then
-    	assert_not_contains "$cpuinfo" "x2apic" "not disabled in /proc/cpuinfo, but config.h defines X2APIC=0"
+    assert_not_contains "$cpuinfo" "x2apic" "not disabled in /proc/cpuinfo, but config.h defines X2APIC=0"
 else
-    	assert_contains "$cpuinfo" "x2apic" "not enabled in /proc/cpuinfo, but config.h defines X2APIC=1"
-    	assert_not_contains "$dmesg_output" "BIOS sets x2apic opt out bit" \
-		"even if X2APIC=1 in config.h and x2apic enabled in /proc/cpuinfo, BIOS is opting out; try intremap=no_x2apic_opt_out in kernel params or disable x2apic"
+    assert_contains "$cpuinfo" "x2apic" "not enabled in /proc/cpuinfo, but config.h defines X2APIC=1"
 fi
 end_check
 

--- a/libsgxstep/apic.c
+++ b/libsgxstep/apic.c
@@ -33,6 +33,13 @@ uint64_t g_apic_deadline_tsc_begin = -1;
 /* See irq_entry.S to see how these are used. */
 void __wrmsr_gate(void);
 void __rdmsr_gate(void);
+
+static void __install_msr_gates()
+{
+	install_priv_gate(__wrmsr_gate, WRMSR_GATE_VECTOR);
+	install_priv_gate(__rdmsr_gate, RDMSR_GATE_VECTOR);
+}
+
 #if !X2APIC
     extern void *apic_base;
     
@@ -62,8 +69,7 @@ void __rdmsr_gate(void);
         apic_base = remap(apic_base_addr);
         libsgxstep_info("established local memory mapping for APIC_BASE=%p at %p", (void*) apic_base_addr, apic_base);
 
-        install_priv_gate(__wrmsr_gate, WRMSR_GATE_VECTOR);
-        install_priv_gate(__rdmsr_gate, RDMSR_GATE_VECTOR);
+	__install_msr_gates();
     }
 #else /* X2APIC */
     /*
@@ -71,8 +77,7 @@ void __rdmsr_gate(void);
      */
     static void do_apic_init(void)
     {
-        install_priv_gate(__wrmsr_gate, WRMSR_GATE_VECTOR);
-        install_priv_gate(__rdmsr_gate, RDMSR_GATE_VECTOR);
+	__install_msr_gates();
     }
 #endif /* X2APIC */
 

--- a/libsgxstep/apic.c
+++ b/libsgxstep/apic.c
@@ -30,6 +30,9 @@
 int g_apic_setup = 0;
 uint64_t g_apic_deadline_tsc_begin = -1;
 
+/* See irq_entry.S to see how these are used. */
+void __wrmsr_gate(void);
+void __rdmsr_gate(void);
 #if !X2APIC
     extern void *apic_base;
     
@@ -58,12 +61,11 @@ uint64_t g_apic_deadline_tsc_begin = -1;
     
         apic_base = remap(apic_base_addr);
         libsgxstep_info("established local memory mapping for APIC_BASE=%p at %p", (void*) apic_base_addr, apic_base);
+
+        install_priv_gate(__wrmsr_gate, WRMSR_GATE_VECTOR);
+        install_priv_gate(__rdmsr_gate, RDMSR_GATE_VECTOR);
     }
 #else /* X2APIC */
-    /* See irq_entry.S to see how these are used. */
-    void __wrmsr_gate(void);
-    void __rdmsr_gate(void);
-
     /*
      * Install custom ring-0 IRQ gates to read/write privileged X2APIC MSR registers.
      */

--- a/libsgxstep/apic.c
+++ b/libsgxstep/apic.c
@@ -34,10 +34,16 @@ uint64_t g_apic_deadline_tsc_begin = -1;
 void __wrmsr_gate(void);
 void __rdmsr_gate(void);
 
+/*
+ * Install custom ring-0 IRQ gates to read/write privileged X2APIC MSR registers.
+ * These call gates are needed even if X2APIC=0 since apic_timer_deadline_irq
+ * assumes they are installed. IA32_TSC_DEADLINE MSR is available in both X2APIC 
+ * and XAPIC modes.
+ */
 static void __install_msr_gates()
 {
-	install_priv_gate(__wrmsr_gate, WRMSR_GATE_VECTOR);
-	install_priv_gate(__rdmsr_gate, RDMSR_GATE_VECTOR);
+    install_priv_gate(__wrmsr_gate, WRMSR_GATE_VECTOR);
+    install_priv_gate(__rdmsr_gate, RDMSR_GATE_VECTOR);
 }
 
 #if !X2APIC
@@ -69,15 +75,12 @@ static void __install_msr_gates()
         apic_base = remap(apic_base_addr);
         libsgxstep_info("established local memory mapping for APIC_BASE=%p at %p", (void*) apic_base_addr, apic_base);
 
-	__install_msr_gates();
+        __install_msr_gates();
     }
 #else /* X2APIC */
-    /*
-     * Install custom ring-0 IRQ gates to read/write privileged X2APIC MSR registers.
-     */
     static void do_apic_init(void)
     {
-	__install_msr_gates();
+        __install_msr_gates();
     }
 #endif /* X2APIC */
 


### PR DESCRIPTION
## Patches
The following were preformed:
1. Call gates rdmsr/wrmsr are always available
2. In `app/selftest/idt` consider if APIC_ID msr is available only if x2apic is enabled
3. `check_sys.sh` now considers if BIOS has enabled opt out bit for x2apic

## Specifics
Regarding 1: The following line assumes the handlers have been installed:
https://github.com/jovanbulck/sgx-step/blob/1e7dc627e9ce10baeda5b434a2faf3bdb88aa493/libsgxstep/apic.c#L127

IA32_TSC_DEADLINE MSR is available in both x2APIC and xAPIC modes of operations therefore including these call gates regardless if x2APIC is set is beneficial for the apic deadline mode.

Regarding 3: Even if `nox2apic` is not included as a kernel parameter and the system supports x2apic mode it might be that the BIOS has enabled the opt out bit for x2apic, effectively trumping the absence of `nox2apic`. The script now includes checks for this scenario.