### PR TITLE
submodules: update Intel repo URLs to canonical names to fix CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "kernel/linux-sgx-driver"]
 	path = kernel/linux-sgx-driver
-	url = https://github.com/01org/linux-sgx-driver.git
+	url = https://github.com/intel/linux-sgx-driver.git
 [submodule "sdk/intel-sdk/linux-sgx"]
 	path = sdk/intel-sdk/linux-sgx
-	url = https://github.com/01org/linux-sgx.git
+	url = https://github.com/intel/confidential-computing.sgx.git
 [submodule "sdk/gramine"]
 	path = sdk/gramine/gramine
 	url = https://github.com/gramineproject/gramine.git


### PR DESCRIPTION
After #104 the `intel-sdk` and `oe-sdk` jobs have been failing at submodule fetch:

```
fatal: clone of 'https://github.com/01org/confidential-computing.tee.dcap.git' into submodule path '.../external/dcap_source' failed
```

linux-sgx v2.29 points to `dcap_source` via a relative URL (`../confidential-computing.tee.dcap.git`). Git resolves that against the parent submodule URL before following any HTTP redirects, so a parent URL of `01org/linux-sgx` makes the sibling resolve to `01org/confidential-computing.tee.dcap`, which doesn't exist. Earlier linux-sgx versions used an absolute URL here, which is why this only broke after #104.

Switching the linux-sgx submodule to Intel's current name (`intel/confidential-computing.sgx`) makes the sibling resolve to `intel/confidential-computing.tee.dcap` (HTTP 200), and `git submodule update` works again. `linux-sgx-driver` is updated to `intel/linux-sgx-driver` in the same commit for consistency; the old `01org/` URL still 301-redirects, so that part is cosmetic.

Sorry, I should have caught the relative-URL behavior when verifying #104.