### PR TITLE
libsgxstep/tracer: guard sources with #if !NO_SGX

### DIFF
--- a/libsgxstep/sgx_tracer.c
+++ b/libsgxstep/sgx_tracer.c
@@ -1,3 +1,5 @@
+#if !NO_SGX
+
 #include "sgx_tracer.h"
 
 static void generate_ids(char (*ids)[4], size_t count);
@@ -284,3 +286,5 @@ static void generate_ids(char (*ids)[4], size_t count)
     }
 }
 /* ============================================================= */
+
+#endif /* !NO_SGX */

--- a/libsgxstep/trace_gprs.c
+++ b/libsgxstep/trace_gprs.c
@@ -1,3 +1,5 @@
+#if !NO_SGX
+
 #include "trace_module.h"
 #include "debug.h"
 #include "pt.h"
@@ -159,3 +161,5 @@ trace_module_t* trace_gprs_create(void)
 
     return m;
 }
+
+#endif /* !NO_SGX */

--- a/libsgxstep/trace_irq_latency.c
+++ b/libsgxstep/trace_irq_latency.c
@@ -1,3 +1,5 @@
+#if !NO_SGX
+
 #include "trace_module.h"
 
 #include "debug.h"
@@ -100,3 +102,5 @@ trace_module_t* trace_irq_create(void)
 
     return m;
 }
+
+#endif /* !NO_SGX */

--- a/libsgxstep/trace_pages.c
+++ b/libsgxstep/trace_pages.c
@@ -1,3 +1,5 @@
+#if !NO_SGX
+
 #include "trace_module.h"
 #include "debug.h"
 #include "pt.h"
@@ -218,3 +220,5 @@ trace_module_t* trace_pages_create(void)
 
     return m;
 }
+
+#endif /* !NO_SGX */


### PR DESCRIPTION
After #101 the `selftest` job has been failing because the new tracer sources in `libsgxstep/` reference SGX-only types unconditionally:

```
trace_gprs.c:10:24: error: field 'sgx_gpr_off' has incomplete type
trace_gprs.c:23:41: error: unknown type name 'gprsgx_region_t'
trace_gprs.c:28:19: error: 'X' undeclared (first use in this function)
```

`enclave.h` puts `gprsgx_region_t`, `enum gprsgx_offset`, `gpr_all`, `ALL_GPRS`, and the `nemesis_tsc_*` externs under `#if !NO_SGX`. `trace_gprs.c`, `trace_irq_latency.c`, `trace_pages.c`, and `sgx_tracer.c` use those names directly, so libsgxstep fails to compile whenever a consumer (e.g. `app/selftest/*`) sets `NO_SGX=1`.

This wraps each of the four new tracer sources with `#if !NO_SGX` / `#endif`, matching the convention already used in `enclave.c`. Under `NO_SGX=1` the tracer translation units expand to nothing; the headers (`sgx_tracer.h`, `trace_module.h`) don't pull in SGX types, so callers that don't actually invoke the tracer aren't affected.

Verified locally by running the selftest build step under act with `NO_SGX=1`: `libsgxstep/`, all `app/selftest/*`, and `app/baresgx/` now build cleanly.